### PR TITLE
allow configuring edit mode paramters via CLI or config.toml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +352,15 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -1145,12 +1203,16 @@ dependencies = [
  "bevy",
  "bevy_egui",
  "bevy_pancam",
+ "clap",
  "cpal",
  "crossbeam-channel",
  "egui",
  "egui_extras",
+ "figment",
  "fundsp",
+ "serde",
  "syn 2.0.95",
+ "xdg",
 ]
 
 [[package]]
@@ -1394,6 +1456,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1513,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -2000,6 +2108,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2438,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2645,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -3965,6 +4098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,6 +4242,12 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "svg_fmt"
@@ -4506,10 +4654,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4518,6 +4681,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -4638,6 +4803,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,6 +4857,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -5506,6 +5686,12 @@ name = "xcursor"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xkbcommon-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ fundsp = {version = "0.20", git = "https://github.com/SamiPerttu/fundsp"}
 cpal = {version = "0.15.3", features = ["jack"]}
 syn = {version = "2.0", features = ["full", "extra-traits"]}
 crossbeam-channel = "0.5"
+clap = { version = "4.5.23", features = ["derive"] }
+figment = { version = "0.10.19", features = ["toml"]}
+xdg = "2.5.2"
+serde = { version = "1.0.215", features = ["derive"] }
 
 # smol amount of optimization for our stuff
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ cd bgawk
 cargo run --release
 ```
 
+If you're building bgawk often then you might want to improve your compile times by dyanically linking bevy appending 
+`--features bevy/dynamic_linking` to your build or run commands.
+
+You can configure bgawk via the command line or by placing a `config.toml` at `$HOME/.config/bawk/config.toml`.
+For more information see [src/config.rs](./src/config.rs) or run:
+```
+cargo run -- --help
+```
+
 ## thanks
 
 - avian https://github.com/Jondolf/avian
@@ -27,3 +36,7 @@ cargo run --release
 - cpal https://github.com/rustaudio/cpal
 - bevy_pancam https://github.com/johanhelsing/bevy_pancam
 - crossbeam_channel https://github.com/crossbeam-rs/crossbeam
+- clap https://github.com/clap-rs/clap
+- figment https://github.com/SergioBenitez/Figment
+- xdg https://github.com/whitequark/rust-xdg
+- serde https://github.com/serde-rs/serde

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,66 @@
+use crate::objects::AttractionFactor;
+use crate::ui::ZoomFactor;
+use avian2d::prelude::Gravity;
+use bevy::app::{App, Plugin, PostStartup};
+use bevy::prelude::{Res, ResMut, Resource};
+use bevy::time::{Time, Virtual};
+use clap::Parser;
+use figment::{providers::{Format, Serialized, Toml}, Figment};
+use serde::{Deserialize, Serialize};
+use xdg::BaseDirectories;
+
+pub struct ConfigPlugin;
+
+#[derive(Parser, Debug, Resource, Serialize, Deserialize)]
+#[command(version, about, long_about = None)]
+pub struct Config {
+
+    #[arg(long, default_value_t = false)]
+    pub pause: bool,
+
+    #[arg(long, default_value_t = 0.0)]
+    pub gravity_x: f32,
+
+    #[arg(long, default_value_t = 0.0)]
+    pub gravity_y: f32,
+
+    #[arg(long, default_value_t = 0.01)]
+    pub attraction: f32,
+
+    #[arg(long, default_value_t = 1.0)]
+    pub zoom: f32,
+}
+
+impl Plugin for ConfigPlugin {
+    fn build(&self, app: &mut App) {
+        let xdg_dirs = BaseDirectories::with_prefix("bgawk").unwrap();
+        let config_path = xdg_dirs.place_config_file("config.toml").unwrap();
+
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::parse()))
+            .merge(Toml::file(config_path))
+            .extract().unwrap();
+
+        app.insert_resource(config)
+            .add_systems(PostStartup, configure);
+    }
+}
+
+fn configure(
+    config: Res<Config>,
+    mut time: ResMut<Time<Virtual>>,
+    mut gravity: ResMut<Gravity>,
+    mut attraction_factor: ResMut<AttractionFactor>,
+    mut zoom_factor: ResMut<ZoomFactor>,
+) {
+    if config.pause {
+        time.pause();
+    }
+
+    gravity.0.x = config.gravity_x;
+    gravity.0.y = config.gravity_y;
+
+    attraction_factor.0 = config.attraction;
+
+    zoom_factor.0 = config.zoom;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,10 @@ mod joints;
 mod lapis;
 mod objects;
 mod ui;
+mod config;
+
 use {interaction::*, joints::*, lapis::*, objects::*, ui::*};
+use config::ConfigPlugin;
 
 fn main() {
     App::new()
@@ -48,6 +51,7 @@ fn main() {
             angular: -1.,
         })
         .add_systems(Startup, setup)
+        .add_plugins(ConfigPlugin)
         .run();
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,7 +31,7 @@ struct InsertComponents {
 }
 
 #[derive(Resource)]
-struct ZoomFactor(f32);
+pub struct ZoomFactor(pub f32);
 
 fn egui_ui(
     mut contexts: EguiContexts,


### PR DESCRIPTION
Whenever I run bgawk I first set my edit mode parameters. During a session, I'd often keep these constant. This change allows setting the edit mode parameters via the CLI or using a config.toml file. 